### PR TITLE
(Fix) dropped first url

### DIFF
--- a/bin/decrypt-dlc
+++ b/bin/decrypt-dlc
@@ -44,7 +44,7 @@ if (isFile(program.args[0]) && isDLCFile(program.args[0])) {
   decrypt.upload(program.args[0], (err, response) => {
     if (err) throw err;
 
-    urls = response.success.links.slice(1).join('\n');
+    urls = response.success.links.join('\n');
     storeUrlsInFile(urls);
   });
 } else if (isFile(program.args[0]) && !isDLCFile(program.args[0])) {
@@ -54,7 +54,7 @@ if (isFile(program.args[0]) && isDLCFile(program.args[0])) {
     decrypt.paste(content, (err, response) => {
       if (err) throw err;
 
-      urls = response.success.links.slice(1).join('\n');
+      urls = response.success.links.join('\n');
       storeUrlsInFile(urls);
     });
   });
@@ -62,7 +62,7 @@ if (isFile(program.args[0]) && isDLCFile(program.args[0])) {
   decrypt.container(program.args[0], (err, response) => {
     if (err) throw err;
 
-    urls = response.success.links.slice(1).join('\n');
+    urls = response.success.links.join('\n');
     storeUrlsInFile(urls);
   });
 } else {


### PR DESCRIPTION
I've noticed that `decrypt-dlc` drops the first url from the DLC file.

Maybe adding some tests which compare the output of `decrypt-dlc` with the source for the DLC could help. Additionally, it would be nice to use `stdout` instead of `urls.txt` when `-o` is not given as this makes using it in shell scripts easier.